### PR TITLE
Begin utilizing SourceCred

### DIFF
--- a/functions/mergeAccounts.js
+++ b/functions/mergeAccounts.js
@@ -1,8 +1,22 @@
 // functions/mergeAccounts.js
-exports.handler = async event => {
-  const subject = event.queryStringParameters.name || 'World'
+import sc from "sourcecred";
+
+exports.handler = async (event) => {
+  const repo = event.queryStringParameters.repo || "sourcecred/cred";
+
+  const instance = sc.sourcecred.instance.readInstance.getNetworkReadInstance(
+    `https://raw.githubusercontent.com/${repo}/gh-pages/`
+  );
+  const timestamp = (await instance.readCredGraph())
+    .intervals()
+    .reduce((_, v) => v.endTimeMs);
+  const subject = event.queryStringParameters.name || "World";
   return {
     statusCode: 200,
-    body: `Hello ${subject}!`,
-  }
-}
+    body: `
+Hello ${subject}!\n
+The last interval ended on ${new Date(timestamp)} \
+for the ${repo} cred instance.
+    `,
+  };
+};


### PR DESCRIPTION
This is a PR because it'll break the deploy until a fix is merged in
sourcecred/sourcecred. Once the fix is published, we'll be good to go.

Specifically, the `module` path specified in sourcecred/sourcecred
fails to build with netlify's transpiler. If you want to continue
working with the sourcecred import, just delete the line with
`  "module": "src/api/index.js",`
and netlify will be able to build and deploy the function locally, for
further development